### PR TITLE
Update formtags.py

### DIFF
--- a/formtags/templatetags/formtags.py
+++ b/formtags/templatetags/formtags.py
@@ -149,7 +149,7 @@ def bwrap(field, break_after_label=False):
 
 def blabel(field, label=_USE_FIELD_DATA):
     """Change the label of the given field."""
-    print label, repr(label), type(label)
+    #print label, repr(label), type(label)
     return BField.factory(field, label=label)
 
 


### PR DESCRIPTION
An issue working with python 3.x, line number 152 throws an error. It would be good to either comment the line, change it to a function as in python3 or remove it completely.